### PR TITLE
Add support for custom separator and negative dirLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Let's say the file to be processed has a relative path of `/src/client/pages/com
 
 And the file has content of:
 ```jsx
-// src/client/Components/Common/Header.jsx
 <View>
   ...
 </View>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ And the file has content of:
 
 Now if we pass in `dirLevel: 2`, the generated data id would look like:
 ```jsx
-<View data-id="tables_MyCustomTable_View">
+<View data-id="common_tables_MyCustomTable_View">
   ...
 </View>
 ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ npm install --save-dev babel-plugin-react-generate-property
 
 <details>
 <summary>Negative dirLevel example</summary>
+
 Let's say the file to be processed has a relative path of `/src/client/pages/common/tables/MyCustomTable.jsx`.
 
 And the file has content of:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ $ npm install --save-dev babel-plugin-react-generate-property
 
 **customSeparator**: Use this to configure the separator used between generated property value, for example, setting it to "-" would yield something like `<div data-id="Common-Header-div-wrapper" />`. By default it would be "_".
 
-**dirLevel**: How many levels of the file directory do you want to use for the property value. If you use more, the generated value is more likely to be unique, but you will also incur slightly larger builds. Default to 1 (append only the directory where the target file is located in). You may also set dirLevel to a negative value, in which case, the plugin will strip the first `-dirLevel` directory values from the beginning, instead of keeping values from the end.
+**dirLevel**: How many levels of the file directory do you want to use for the property value. If you use more, the generated value is more likely to be unique, but you will also incur slightly larger builds. Default to 1 (append only the directory where the target file is located in). 
+
+You may also set dirLevel to a negative value, in which case, the plugin will strip the first `-dirLevel` directory values from the beginning, instead of keeping values from the end.
 
 <details>
 <summary>Negative dirLevel example</summary>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ $ npm install --save-dev babel-plugin-react-generate-property
 ```
 **customProperty**: Use this to configure which property to add to open tags. By default it would be "data-id".
 
+**customSeparator**: Use this to configure the separator used between generated property value, for example, setting it to "-" would yield something like `<div data-id="Common-Header-div-wrapper" />`. By default it would be "_".
+
 **dirLevel**: How many levels of the file directory do you want to use for the property value. If you use more, the generated value is more likely to be unique, but you will also incur slightly larger builds. Default to 1 (append only the directory where the target file is located in)
 
 **omitFileName**  (default: `false`): In case you want to omit filename in data-attr

--- a/README.md
+++ b/README.md
@@ -87,7 +87,37 @@ $ npm install --save-dev babel-plugin-react-generate-property
 
 **customSeparator**: Use this to configure the separator used between generated property value, for example, setting it to "-" would yield something like `<div data-id="Common-Header-div-wrapper" />`. By default it would be "_".
 
-**dirLevel**: How many levels of the file directory do you want to use for the property value. If you use more, the generated value is more likely to be unique, but you will also incur slightly larger builds. Default to 1 (append only the directory where the target file is located in)
+**dirLevel**: How many levels of the file directory do you want to use for the property value. If you use more, the generated value is more likely to be unique, but you will also incur slightly larger builds. Default to 1 (append only the directory where the target file is located in). You may also set dirLevel to a negative value, in which case, the plugin will strip the first `-dirLevel` directory values from the beginning, instead of keeping values from the end.
+
+<details>
+<summary>Negative dirLevel example</summary>
+Let's say the file to be processed has a relative path of `/src/client/pages/common/tables/MyCustomTable.jsx`.
+
+And the file has content of:
+```jsx
+// src/client/Components/Common/Header.jsx
+<View>
+  ...
+</View>
+```
+
+Now if we pass in `dirLevel: 2`, the generated data id would look like:
+```jsx
+<View data-id="tables_MyCustomTable_View">
+  ...
+</View>
+```
+
+But if `dirLevel: -2` is passed, the plugin would strip relative path from the beginning, and generate something like:
+```jsx
+<View data-id="client_pages_common_tables_MyCustomTable_View">
+  ...
+</View>
+```
+
+Note that a dirLevel value of `-2` essentially stripped off both the rootDir, and then the `src/` part of the relative path.
+
+</details>
 
 **omitFileName**  (default: `false`): In case you want to omit filename in data-attr
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-react-generate-property",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A plugin to automatically generate properties (for example data attributes) for all JSX open tags, using user specified convention",
   "main": "lib/index.js",
   "directories": {
@@ -42,6 +42,5 @@
     "prettier": "^2.4.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ module.exports = declare(api => {
         } = state.opts
 
         const filename = state.file.opts.filename || '' // filename missing in test env, see tests
+        const rootDir = state.file.opts.root
+        const relativePath = filename.slice(rootDir.length)
 
         const splits = filename.split(slashChar)
         if (!splits || !splits.length) {
@@ -32,8 +34,13 @@ module.exports = declare(api => {
           )
           return
         }
+        const relativePathSplits = relativePath.split(slashChar)
 
-        const dirNames = splits.slice(-1 - dirLevel, -1)
+        // User may specify negative dirLevel, to STRIP the first x layers instead of KEEPING last x layers
+        const dirNames =
+          dirLevel >= 0
+            ? splits.slice(-1 - dirLevel, -1)
+            : relativePathSplits.slice(-dirLevel, -1)
 
         const fileName = splits[splits.length - 1].split('.')[0]
         const fileIdentifier = `${dirNames.join(customSeparator)}${

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = declare(api => {
         // Get user configs
         const {
           customProperty = 'data-id',
+          customSeparator = '_',
           slashChar = '/',
           dirLevel = 1,
           addModuleClassNames = false,
@@ -35,8 +36,8 @@ module.exports = declare(api => {
         const dirNames = splits.slice(-1 - dirLevel, -1)
 
         const fileName = splits[splits.length - 1].split('.')[0]
-        const fileIdentifier = `${dirNames.join('_')}${
-          omitFileName ? '' : `_${fileName}`
+        const fileIdentifier = `${dirNames.join(customSeparator)}${
+          omitFileName ? '' : `${customSeparator}${fileName}`
         }`
         let previousNodeName = ''
         let index = 0
@@ -58,7 +59,8 @@ module.exports = declare(api => {
               const classNames = classNodes
                 .map(x => x?.value?.expression?.property?.name)
                 .filter(Boolean)
-              className = classNames.length > 0 ? classNames.join('_') : ''
+              className =
+                classNames.length > 0 ? classNames.join(customSeparator) : ''
             }
 
             // Traverse once to get the element node name (div, Header, span, etc)
@@ -98,6 +100,7 @@ module.exports = declare(api => {
             if (!dataIDDefined && nodeName && nodeName !== 'Fragment') {
               const params = {
                 path: fileIdentifier,
+                customSeparator,
                 nodeName,
                 previousNodeName,
                 index,
@@ -133,6 +136,7 @@ module.exports = declare(api => {
 function nameGenerator(params, options) {
   const prefix = options.prefix || null
   const regexPrefix = params.regex || null
+  const separator = params.customSeparator || '_'
 
   const path = params.path || null
   const nodeName = options.ignoreNodeNames ? null : params.nodeName || null
@@ -149,7 +153,7 @@ function nameGenerator(params, options) {
 
   return [prefix, regexPrefix, path, nodeName, index, className]
     .filter(Boolean)
-    .join('_')
+    .join(separator)
 }
 
 function startsWithUpperCase(s) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -35,35 +35,41 @@ const ex5b = babel.transformSync(ex2, {
   plugins: [[plugin, { customProperty: 'data-test-element' }]]
 })
 
+const ex6b = babel.transformSync(ex2, {
+  filename: 'fname.js',
+  presets: ['@babel/preset-react'],
+  plugins: [[plugin, { customSeparator: '-' }]]
+})
+
 describe('Basic functionality', () => {
-  describe('DOM node name', function() {
-    it('should be read', function() {
+  describe('DOM node name', function () {
+    it('should be read', function () {
       const output = eval(ex1b.code)
       assert.equal(output.props['data-id'], '__div')
     })
   })
 
-  describe('React node name', function() {
-    it('should be read', function() {
+  describe('React node name', function () {
+    it('should be read', function () {
       const output = eval(ex2b.code)
       assert.equal(output.props['data-id'], '__App')
     })
   })
 
-  describe('Index', function() {
-    it('should be count and put into the tree', function() {
+  describe('Index', function () {
+    it('should be count and put into the tree', function () {
       const output = eval(ex1b.code)
       assert.equal(output.props.children.props['data-id'], '__div_1')
     })
 
-    it('should not be count in case of different nodes', function() {
+    it('should not be count in case of different nodes', function () {
       const output = eval(ex2b.code)
       assert.equal(output.props.children.props['data-id'], '__div')
     })
   })
 
-  describe('Dirname', function() {
-    it('should be read', function() {
+  describe('Dirname', function () {
+    it('should be read', function () {
       const output = eval(ex3b.code)
       assert.equal(
         output.props['data-id'],
@@ -71,16 +77,26 @@ describe('Basic functionality', () => {
       )
     })
 
-    it('should be ignored in case of dirLevel 0', function() {
+    it('should be ignored in case of dirLevel 0', function () {
       const output = eval(ex4b.code)
       assert.equal(output.props['data-id'], '_fname_App')
     })
   })
 
-  describe('Custom property', function() {
-    it('should be custom', function() {
+  describe('Custom property', function () {
+    it('should be custom', function () {
       const output = eval(ex5b.code)
       assert.equal(output.props['data-test-element'], '__App')
+    })
+  })
+
+  describe('Custom separator', function () {
+    it('should be custom', function () {
+      const output = eval(ex6b.code)
+      assert.equal(
+        output.props['data-id'],
+        'babel-plugin-react-generate-property-fname-App'
+      )
     })
   })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -41,6 +41,24 @@ const ex6b = babel.transformSync(ex2, {
   plugins: [[plugin, { customSeparator: '-' }]]
 })
 
+const ex7b = babel.transformSync(ex2, {
+  filename: 'my/deep/custom/dir/fname.js',
+  presets: ['@babel/preset-react'],
+  plugins: [[plugin, { dirLevel: 2 }]]
+})
+
+const ex8b = babel.transformSync(ex2, {
+  filename: 'my/deep/custom/dir/fname.js',
+  presets: ['@babel/preset-react'],
+  plugins: [[plugin, { dirLevel: -2 }]]
+})
+
+const ex9b = babel.transformSync(ex2, {
+  filename: 'fname.js',
+  presets: ['@babel/preset-react'],
+  plugins: [[plugin, { dirLevel: -2 }]]
+})
+
 describe('Basic functionality', () => {
   describe('DOM node name', function () {
     it('should be read', function () {
@@ -97,6 +115,23 @@ describe('Basic functionality', () => {
         output.props['data-id'],
         'babel-plugin-react-generate-property-fname-App'
       )
+    })
+  })
+
+  describe('Directory level', function () {
+    it('should accept dirLevel of greater than 1', function () {
+      const output = eval(ex7b.code)
+      assert.equal(output.props['data-id'], 'custom_dir_fname_App')
+    })
+
+    it('should accept negative dirLevel', function () {
+      const output = eval(ex8b.code)
+      assert.equal(output.props['data-id'], 'deep_custom_dir_fname_App')
+    })
+
+    it('should accept negative dirLevel and shallow file path', function () {
+      const output = eval(ex9b.code)
+      assert.equal(output.props['data-id'], '_fname_App')
     })
   })
 })


### PR DESCRIPTION
- User may now pass `customSeparator` (previously default to `_` only).
- User may specify a negative `dirLevel` value, to strip off `-dirLevel` levels of directories from the beginning.