### PR TITLE
fix: slash should be OS-specific

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 .eslintrc
 .github
+test
+.babelrc
+.prettierrc
 *.DS_Store
 *npm-debug.log
 *yarn-error.log

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ npm install --save-dev babel-plugin-react-generate-property
           "babel-plugin-react-generate-property", {
             "customProperty": "data-dev",
             "dirLevel": 2,
-            "slashChar": "\",
+            "slashChar": "\\",
             "addModuleClassNames": true,
             "prefix": "myPrefix",
             "firstChildOnly": false
@@ -123,7 +123,7 @@ Note that a dirLevel value of `-2` essentially stripped off both the rootDir, an
 
 **omitFileName**  (default: `false`): In case you want to omit filename in data-attr
 
-**slashChar**: Default to "/", if you are on Windows, use "\".
+**slashChar**: Default to OS-specific path separator character.
 
 **addModuleClassNames**  (default: `false`) : In case you use css-modules and want to add className to data-attribute:
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const { declare } = require('@babel/helper-plugin-utils')
 const { types: t } = require('@babel/core')
 
@@ -12,7 +13,7 @@ module.exports = declare(api => {
         const {
           customProperty = 'data-id',
           customSeparator = '_',
-          slashChar = '/',
+          slashChar = path.sep,
           dirLevel = 1,
           addModuleClassNames = false,
           prefix = '',
@@ -30,7 +31,7 @@ module.exports = declare(api => {
         const splits = filename.split(slashChar)
         if (!splits || !splits.length) {
           console.error(
-            'babel-plugin-react-generate-property plugin error: File path is not valid. If you are on Windows, you might need to specify backslash as slashChar in options.'
+            'babel-plugin-react-generate-property plugin error: File path is not valid'
           )
           return
         }


### PR DESCRIPTION
On Windows this library does not work well, because you hardcoded `slachCode` to be Mac/Linux specific. On Windows slashes are different and because of that paths are not parsed properly, resulting in such monstosities: `"data-id"="_C:\\yhnavein\\os\\babel-plugin-react-generate-property\\fname"`.
This also means that your tests were failing on Windows. After this fix tests are passing just fine.

Hopefully it was easy to fix using `path.sep` which offers OS-dependent slash character :)

And I know it's possible to specify custom `slashChar` but it's not very convenient. Not to mention failing tests on Windows. 

I've also reduced npm package size by ignoring test files and some dot files.