### PR TITLE
fix: prepend new props rather than append them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ module.exports = declare(api => {
               }
 
               filteringOptionsCheck &&
-                jsxPath.node.openingElement.attributes.push(
+                jsxPath.node.openingElement.attributes.unshift(
                   t.jSXAttribute(
                     t.jSXIdentifier(customProperty),
                     t.stringLiteral(nameGenerator(params, state.opts))


### PR DESCRIPTION
closes https://github.com/shawnxusy/babel-plugin-react-generate-property/issues/11